### PR TITLE
Command Injection vul fix: Replace execSync with execFileSync

### DIFF
--- a/packages/react-dev-utils/getProcessForPort.js
+++ b/packages/react-dev-utils/getProcessForPort.js
@@ -9,6 +9,7 @@
 
 var chalk = require('chalk');
 var execSync = require('child_process').execSync;
+var execFileSync = require('child_process').execFileSync;
 var path = require('path');
 
 var execOptions = {
@@ -25,7 +26,7 @@ function isProcessAReactApp(processCommand) {
 }
 
 function getProcessIdOnPort(port) {
-  return execSync('lsof -i:' + port + ' -P -t -sTCP:LISTEN', execOptions)
+  return execFileSync('lsof', ['-i:'+port, '-P', '-t', '-sTCP:LISTEN'], execOptions)
     .split('\n')[0]
     .trim();
 }


### PR DESCRIPTION
### 📊 Metadata *

react-dev-utils includes some utilities used by Create React App.

The function getProcessForPort in react-dev-utils is vulnerable to command injection.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-react-dev-utils/

### ⚙️ Description *
Used child_process.execFileSync() instead of child_process.execSync().

### 💻 Technical Description *
The use of the child_process function execSync() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFileSync() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Create a .js file with the content below and run it, then the file pzhou@shu can be illegally created.

// poc.js
var getProcessForPort = require('react-dev-utils/getProcessForPort');

getProcessForPort('11;$(touch pzhou@shu)');

### 🔥 Proof of Fix (PoF) *

use "return execFileSync('lsof', ['-i:'+port, '-P', '-t', '-sTCP:LISTEN'], execOptions)" to replace "return execSync('lsof -i:' + port + ' -P -t -sTCP:LISTEN', execOptions)"

### 👍 User Acceptance Testing (UAT)

var getProcessForPort = require('react-dev-utils/getProcessForPort');

getProcessForPort(3000) // works correctly

### 🔗 Relates to...
https://github.com/418sec/huntr/pull/1962




